### PR TITLE
Upgrade the Anaconda project version to 0.10.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.9.1" %}
+{% set version = "0.10.0" %}
 
 package:
   name: anaconda-project
@@ -6,11 +6,11 @@ package:
 
 source:
   url: https://github.com/Anaconda-Platform/anaconda-project/archive/v{{ version }}.tar.gz
-  sha256: f578d0d242cb78605933992c67acb559a5e93a5108bb575faeb9361b7e1f44ca
+  sha256: 4b3f444ad3f75af454a92b797bf8a1a4d5b4070f2bb50692736f47373c4bdbd4
 
 build:
   noarch: python
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps
   entry_points:
     - anaconda-project = anaconda_project.cli:main
@@ -22,6 +22,7 @@ requirements:
 
   run:
     - anaconda-client
+    - conda-pack
     - python >=2.7
     - requests
     - ruamel_yaml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps
   entry_points:
     - anaconda-project = anaconda_project.cli:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   noarch: python
   number: 0
-  script: "{{ PYTHON }} -m pip install . -vv --no-deps"
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
   entry_points:
     - anaconda-project = anaconda_project.cli:main
 
@@ -26,6 +26,7 @@ requirements:
     - requests
     - ruamel_yaml
     - tornado >=4.2
+    - jinja2
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.8.4" %}
+{% set version = "0.9.0" %}
 
 package:
   name: anaconda-project
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/Anaconda-Platform/anaconda-project/archive/v{{ version }}.tar.gz
-  sha256: 0b57e51e0d75f63602e8929c612b128d5a0704fdd38354c52c150f3007dbebfb
+  sha256: d89b4a6775b3d94762c1064b4ba57273a81a37833772c07b6d282586e1fe305e
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/Anaconda-Platform/anaconda-project/archive/v{{ version }}.tar.gz
-  sha256: d89b4a6775b3d94762c1064b4ba57273a81a37833772c07b6d282586e1fe305e
+  sha256: d1c99724bed31a87f28257720a7f0916a8d2b7e4ff3687b46c2a3de06e95b186
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.9.0" %}
+{% set version = "0.9.1" %}
 
 package:
   name: anaconda-project
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/Anaconda-Platform/anaconda-project/archive/v{{ version }}.tar.gz
-  sha256: d1c99724bed31a87f28257720a7f0916a8d2b7e4ff3687b46c2a3de06e95b186
+  sha256: f578d0d242cb78605933992c67acb559a5e93a5108bb575faeb9361b7e1f44ca
 
 build:
   noarch: python


### PR DESCRIPTION
1. Added conda-pack dependency
2. Bump version to 0.10.0
3. Updated SHA


Package build successfully in concourse.